### PR TITLE
Fixing `puma` in production ENV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'concurrent-ruby', '~> 1.0', require: false
 gem 'dalli', '~> 2.7'
 gem 'logstasher', '~> 1.2'
 gem 'occi-core', '~> 5.0', require: 'occi/infrastructure-ext'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  concurrent-ruby (~> 1.0)
   dalli (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   logstasher (~> 1.2)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match


### PR DESCRIPTION
When launching the server in `production` ENV, only the following command works with SSL-only listener:
```shell
export RAILS_ENV=production
export SECRET_KEY_BASE=a271402df66e1527679327482b5ecfa2f353
bundle exec puma
```