### PR TITLE
Fixed bug in loading mixin values to os_tpl in ONe

### DIFF
--- a/app/lib/backends/opennebula/model_extender.rb
+++ b/app/lib/backends/opennebula/model_extender.rb
@@ -96,7 +96,7 @@ module Backends
         os.title = template['TEMPLATE/CLOUDKEEPER_APPLIANCE_TITLE'] || template['NAME']
         os.schema = change_namespace(os.schema)
         os.location = URI.parse("/mixin/os_tpl/#{template['ID']}")
-        OS_TPL_ATTRS.each_pair { |k, v| os[k] = template[v] }
+        OS_TPL_ATTRS.each_pair { |k, v| os[k].default = template[v] }
       end
 
       # :nodoc:


### PR DESCRIPTION
Mixins have only `default` values, there are no attribute values.