### PR TITLE
Examples of `systemd` units

### DIFF
--- a/examples/systemd/occi-server.service
+++ b/examples/systemd/occi-server.service
@@ -13,7 +13,7 @@ Environment="PORT=11443"
 Environment="SECRET_KEY_BASE=a271402df66e152767d7b2149b8773adf242401eb8000e02a55a5d452fe2e47f7cf05969b8b77d1acb6319c9286e13ea3311b3e180115e9327482b5ecfa2f353"
 # Environment="HOST_CERT=/path/to/cert"
 # Environment="HOST_KEY=/path/to/key"
-ExecStart="bundle exec --keep-file-descriptors puma"
+ExecStart="/opt/occi-server/embedded/bin/bundle exec --keep-file-descriptors puma"
 Restart=always
 
 [Install]

--- a/examples/systemd/occi-server.service
+++ b/examples/systemd/occi-server.service
@@ -1,0 +1,20 @@
+[Unit]
+Description="rOCCI-server HTTPS Service"
+After=network.target
+Requires=occi-server.socket
+
+[Service]
+Type=simple
+User=rocci
+WorkingDirectory=/opt/occi-server/embedded/app/rOCCI-server
+Environment="RAILS_ENV=production"
+# Environment="HOST=0.0.0.0"
+Environment="PORT=11443"
+Environment="SECRET_KEY_BASE=a271402df66e152767d7b2149b8773adf242401eb8000e02a55a5d452fe2e47f7cf05969b8b77d1acb6319c9286e13ea3311b3e180115e9327482b5ecfa2f353"
+# Environment="HOST_CERT=/path/to/cert"
+# Environment="HOST_KEY=/path/to/key"
+ExecStart="bundle exec --keep-file-descriptors puma"
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/occi-server.socket
+++ b/examples/systemd/occi-server.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description="rOCCI-server HTTPS Accept Socket"
+
+[Socket]
+# ListenStream=0.0.0.0:11443
+ListenStream=127.0.0.1:11443
+NoDelay=true
+ReusePort=true
+Backlog=1024
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
* Example for the puma-based service unit
* Example for a separate socket-activating unit (allows "hot" restarts)