### PR TITLE
Moved instance actions to async ActiveJobs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.8.3)
     ruby_dep (1.5.0)
     sexp_processor (4.10.0)
     sprockets (3.7.1)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,8 +70,8 @@ Vagrant.configure('2') do |config|
 
       source /etc/profile.d/rvm.sh
       rvm autolibs enable
-      rvm install 2.4.0
-      rvm 2.4.0 do gem install bundler
+      rvm install 2.4.1
+      rvm 2.4.1 do gem install bundler
     SHELL
 
     rocci_server.vm.provision 'shell', inline: <<-SHELL
@@ -89,19 +89,19 @@ Vagrant.configure('2') do |config|
       source /etc/profile.d/rvm.sh
 
       cd $SERVER_DIR
-      rvm 2.4.0 do bundle install --deployment --without development test
+      rvm 2.4.1 do bundle install --deployment --without development test
 
       if [ "x#{ENV['ROCCI_SERVER_INTEGRATION_ONE']}" = "xyes" ] ; then
         export ROCCI_SERVER_BACKEND=opennebula
         export ROCCI_SERVER_OPENNEBULA_ENDPOINT=http://#{ONE_ADDR}:2633/RPC2
 
-        rvm 2.4.0 do bundle exec bin/oneresources create --endpoint $ROCCI_SERVER_OPENNEBULA_ENDPOINT
+        rvm 2.4.1 do bundle exec bin/oneresources create --endpoint $ROCCI_SERVER_OPENNEBULA_ENDPOINT
       fi
 
       export RAILS_ENV=production
       export HOST=0.0.0.0
       export SECRET_KEY_BASE=a271402df66e152767d7b2149b8773adf242401eb8000e02a55a5d452fe2e47f7cf05969b8b77d1acb6319c9286e13ea3311b3e180115e9327482b5ecfa2f353
-      rvm 2.4.0 do bundle exec puma --daemon
+      rvm 2.4.1 do bundle exec puma --daemon
       sleep 5
     SHELL
   end

--- a/app/jobs/opennebula/compute_action_job.rb
+++ b/app/jobs/opennebula/compute_action_job.rb
@@ -1,0 +1,39 @@
+module Opennebula
+  class ComputeActionJob < OpennebulaActionJob
+    # Supported actions
+    ACTIVE_ACTIONS = %w[stop restart suspend].freeze
+    INACTIVE_ACTIONS = %w[start save].freeze
+    ACTIONS = [ACTIVE_ACTIONS, INACTIVE_ACTIONS].flatten.freeze
+
+    # :nodoc:
+    ELM_NAME = 'virtual_machine'.freeze
+
+    private
+
+    # :nodoc:
+    def action_stop(vm, _attributes)
+      vm.poweroff true
+    end
+
+    # :nodoc:
+    def action_restart(vm, _attributes)
+      vm.reboot true
+    end
+
+    # :nodoc:
+    def action_suspend(vm, _attributes)
+      vm.suspend
+    end
+
+    # :nodoc:
+    def action_start(vm, _attributes)
+      vm.resume
+    end
+
+    # :nodoc:
+    def action_save(vm, attributes)
+      new_name = attributes['name'].present? ? attributes['name'] : "saved-compute-#{vm['ID']}-#{Time.now.utc.to_i}"
+      vm.save_as_template new_name, true
+    end
+  end
+end

--- a/app/jobs/opennebula/opennebula_action_job.rb
+++ b/app/jobs/opennebula/opennebula_action_job.rb
@@ -1,0 +1,26 @@
+module Opennebula
+  class OpennebulaActionJob < OpennebulaJob
+    # Performs actions on objects with the given `identifier`.
+    #
+    # @param secret [String] credentials for ONe
+    # @param endpoint [String] ONe XML RPC endpoint
+    # @param args [Hash] OpenNebula job arguments
+    # @option args [String] :identifier object identifier
+    # @option args [String] :action_name name of the action to execute
+    # @option args [Hash] :action_attributes attributes of the action to execute
+    # @option args [String] :required_state state to wait for
+    def perform(secret, endpoint, args = {})
+      super
+
+      name = args.fetch(:action_name)
+      raise "Unsupported action #{name.inspect}" unless self.class::ACTIONS.include?(name)
+
+      obj = send(
+        self.class::ELM_NAME,
+        args.fetch(:identifier),
+        args.fetch(:required_state, nil)
+      )
+      handle { send "action_#{name}", obj, args.fetch(:action_attributes) }
+    end
+  end
+end

--- a/app/jobs/opennebula/opennebula_job.rb
+++ b/app/jobs/opennebula/opennebula_job.rb
@@ -1,0 +1,67 @@
+module Opennebula
+  class OpennebulaJob < ApplicationJob
+    queue_as :opennebula
+
+    # Default timeout in seconds
+    DEFAULT_TIMEOUT = 900
+
+    # :nodoc:
+    HELPER_NS = ::Backends::Opennebula::Helpers
+
+    rescue_from(Errors::JobError) do |ex|
+      logger.error "Delayed job failed: #{ex}"
+    end
+
+    rescue_from(Errors::Backend::EntityTimeoutError) do |_ex|
+      logger.error "Timed out while waiting for job completion [#{DEFAULT_TIMEOUT}s]"
+    end
+
+    rescue_from(Errors::Backend::EntityRetrievalError) do |ex|
+      logger.error "Failed to get instance state when waiting: #{ex}"
+    end
+
+    rescue_from(Errors::Backend::RemoteError) do |ex|
+      logger.fatal "Failed during transition: #{ex}"
+    end
+
+    # Performs job in OpenNebula with given arguments.
+    #
+    # @param secret [String] credentials for ONe
+    # @param endpoint [String] ONe XML RPC endpoint
+    # @param args [Hash] OpenNebula job arguments
+    def perform(secret, endpoint, _args = {})
+      @client = ::OpenNebula::Client.new(secret, endpoint)
+    end
+
+    private
+
+    # :nodoc:
+    def virtual_machine(identifier, state = nil)
+      virtual_machine = ::OpenNebula::VirtualMachine.new_with_id(identifier, @client)
+
+      if state
+        HELPER_NS::Waiter.wait_until(virtual_machine, state, DEFAULT_TIMEOUT, :state_str)
+      else
+        handle { virtual_machine.info }
+      end
+
+      virtual_machine
+    end
+
+    # :nodoc:
+    def image(identifier, _state = nil)
+      image = ::OpenNebula::Image.new_with_id(identifier, @client)
+      handle { image.info }
+      image
+    end
+
+    # :nodoc:
+    def handle
+      rc = yield
+      raise rc.message if ::OpenNebula.is_error?(rc)
+      rc
+    rescue => ex
+      raise Errors::JobError, ex.message
+    end
+  end
+end

--- a/app/jobs/opennebula/storage_action_job.rb
+++ b/app/jobs/opennebula/storage_action_job.rb
@@ -1,0 +1,17 @@
+module Opennebula
+  class StorageActionJob < OpennebulaActionJob
+    # Supported actions
+    ONLINE_ACTIONS = %w[backup].freeze
+    ACTIONS = [ONLINE_ACTIONS].flatten.freeze
+
+    # :nodoc:
+    ELM_NAME = 'image'.freeze
+
+    private
+
+    # :nodoc:
+    def action_backup(image, _attributes)
+      image.clone "storage-#{image['ID']}-#{Time.now.utc.to_i}"
+    end
+  end
+end

--- a/app/lib/backends/opennebula/constants/compute.rb
+++ b/app/lib/backends/opennebula/constants/compute.rb
@@ -8,8 +8,7 @@ module Backends
           'PROLOG' => 'waiting',
           'BOOT' => 'waiting',
           'MIGRATE' => 'waiting',
-          'EPILOG' => 'waiting',
-          'LCM_INIT' => 'waiting'
+          'EPILOG' => 'waiting'
         }.freeze
 
         # Attribute mapping hash for Core
@@ -57,25 +56,6 @@ module Backends
           'eu.egi.fedcloud.compute.gpu.class' => ->(vm, val) { vm['TEMPLATE/PCI[1]/CLASS'] == val },
           'eu.egi.fedcloud.compute.gpu.device' => ->(vm, val) { vm['TEMPLATE/PCI[1]/DEVICE'] == val }
         }.freeze
-
-        # Actions to enable when active
-        ACTIVE_ACTIONS = {
-          'stop' => ->(vm, _ai) { vm.poweroff(true) },
-          'restart' => ->(vm, _ai) { vm.reboot(true) },
-          'suspend' => ->(vm, _ai) { vm.suspend }
-        }.freeze
-
-        # Actions to enable when inactive
-        INACTIVE_ACTIONS = {
-          'start' => ->(vm, _ai) { vm.resume },
-          'save' => lambda do |vm, ai|
-            template_name = ai['name'].present? ? ai['name'] : "saved-compute-#{vm['ID']}-#{Time.now.utc.to_i}"
-            vm.save_as_template(template_name, true)
-          end
-        }.freeze
-
-        # All actions
-        ACTIONS = ACTIVE_ACTIONS.merge(INACTIVE_ACTIONS).freeze
 
         # Mixins to add for contextualization attributes
         CONTEXT_MIXINS = [

--- a/app/lib/backends/opennebula/constants/storage.rb
+++ b/app/lib/backends/opennebula/constants/storage.rb
@@ -25,11 +25,6 @@ module Backends
 
         # All transferable attributes
         TRANSFERABLE_ATTRIBUTES = [ATTRIBUTES_CORE, ATTRIBUTES_INFRA].freeze
-
-        # Actions to enable when online
-        ONLINE_ACTIONS = {
-          'backup' => ->(image, _ai) { image.clone "storage-#{image['ID']}-#{Time.now.utc.to_i}" }
-        }.freeze
       end
     end
   end

--- a/app/lib/backends/opennebula/helpers/deferrable_action.rb
+++ b/app/lib/backends/opennebula/helpers/deferrable_action.rb
@@ -1,0 +1,31 @@
+module Backends
+  module Opennebula
+    module Helpers
+      module DeferrableAction
+        # :nodoc:
+        def deferred_action(identifier, action_instance, klass, state_attr_name)
+          logger.debug { "#{self.class}: Triggering action on instance #{identifier} with #{action_instance.inspect}" }
+          action = action_instance.action
+
+          obj = instance(identifier)
+          unless obj.actions.include?(action)
+            raise Errors::Backend::EntityActionError, "Action cannot be used in state #{obj[state_attr_name]}"
+          end
+
+          klass.perform_later(
+            client_secret(options), options.fetch(:endpoint),
+            identifier: identifier, action_name: action.term,
+            action_attributes: serializable_attributes(action_instance.attributes, :value)
+          )
+
+          Occi::Core::Collection.new
+        end
+
+        # :nodoc:
+        def serializable_attributes(attributes, type)
+          Hash[attributes.map { |k, v| [k, v.send(type)] }]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview
Previously, actions on `compute` and `storage` instances were triggered from inlined lambdas. For long-running actions, this caused unwanted blocking in main server processes. This PR introduces `ActiveJob` workers handling these actions in separate worker threads (async).
## Changes
* Potentially long-running actions must run async
* Removing `LCM_INIT` from `waiting` states
* Using Ruby 2.4.1 for integration tests
## Known Issues
* Created `os_tpl` mixin is not returned from `save` action on `compute` instances
* `CLOUDKEEPER*` and `VMCATCHER*` attributes are not removed from templates in `save` action on `compute` instances