### PR TITLE
Using separate MIME type for `occi+json`

### DIFF
--- a/app/controllers/concerns/renderable.rb
+++ b/app/controllers/concerns/renderable.rb
@@ -3,7 +3,7 @@ module Renderable
 
   # Format constants
   URI_FORMATS = %i[uri_list].freeze
-  FULL_FORMATS = %i[json text headers].freeze
+  FULL_FORMATS = %i[occi_json json text headers].freeze
   ALL_FORMATS = [URI_FORMATS, FULL_FORMATS].flatten.freeze
 
   included do
@@ -18,6 +18,7 @@ module Renderable
 
   # Checks request format and defaults or returns HTTP[406].
   def validate_requested_format!
+    request.format = FULL_FORMATS.first unless request.format && request.format.symbol
     return if ALL_FORMATS.include?(request.format.symbol)
     render_error :not_acceptable, 'Requested media format is not acceptable'
   end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,10 +1,14 @@
-# Be sure to restart your server when you modify this file.
+# Clean-up Rails defaults
+Mime::SET.symbols.each { |mime| Mime::Type.unregister(mime) }
 
-# Add new mime types for use in respond_to blocks:
-# Mime::Type.register "text/richtext", :rtf
+## Our MIME Types
+# Full renderings
+Mime::Type.register 'application/occi+json', :occi_json
+Mime::Type.register 'application/json', :json, %w[text/x-json application/jsonrequest]
+
+# Legacy renderings
 Mime::Type.register 'text/plain', :text, [], %w[txt]
 Mime::Type.register 'text/occi', :headers
-Mime::Type.register 'text/uri-list', :uri_list
 
-Mime::Type.unregister :json # we have to get rid of the old definition first
-Mime::Type.register 'application/json', :json, %w[text/x-json application/jsonrequest application/occi+json]
+# Only for locations
+Mime::Type.register 'text/uri-list', :uri_list

--- a/config/initializers/renderers.rb
+++ b/config/initializers/renderers.rb
@@ -25,3 +25,8 @@ ActionController::Renderers.add :json do |obj, _options|
   self.content_type = Mime::Type.lookup_by_extension(:json)
   obj.to_json
 end
+
+ActionController::Renderers.add :occi_json do |obj, _options|
+  self.content_type = Mime::Type.lookup_by_extension(:occi_json)
+  obj.to_json
+end

--- a/test/integration/common.sh
+++ b/test/integration/common.sh
@@ -91,6 +91,11 @@ function delete {
 
 # get_json '/-/'
 function get_json {
+  get $1 'application/json'
+}
+
+# get_occi_json '/-/'
+function get_occi_json {
   get $1 'application/occi+json'
 }
 
@@ -111,6 +116,11 @@ function post_with_format {
 
 # post_json '/compute/' '/path/to/file.json'
 function post_json {
+  post_with_format $1 $2 'application/json'
+}
+
+# post_occi_json '/compute/' '/path/to/file.json'
+function post_occi_json {
   post_with_format $1 $2 'application/occi+json'
 }
 

--- a/test/integration/dummy.sh
+++ b/test/integration/dummy.sh
@@ -27,7 +27,7 @@ printf "######################################################################\n
 printf "############################## Model #################################\n"
 printf "######################################################################\n"
 
-FORMATS=(plain json)
+FORMATS=(plain json occi_json)
 
 for FORMAT in ${FORMATS[@]} ; do
   MODEL_PATH="/-/"
@@ -70,7 +70,7 @@ printf "############################## Get ###################################\n
 printf "######################################################################\n"
 
 FAKE_ID="a262ad95-c093-4814-8c0d-bc6d475bb845"
-FORMATS=(json plain)
+FORMATS=(occi_json json plain)
 LOCATIONS=(compute network storage ipreservation securitygroup)
 LOCATIONS+=(networkinterface storagelink securitygrouplink)
 
@@ -106,7 +106,7 @@ printf "######################################################################\n
 printf "############################# Create #################################\n"
 printf "######################################################################\n"
 
-FORMATS=(json plain)
+FORMATS=(occi_json json plain)
 LOCATIONS=(compute network storage ipreservation securitygroup)
 LOCATIONS+=(networkinterface storagelink securitygrouplink)
 DATA_DIR="${TESTS_DIR}/data/dummy/"
@@ -114,7 +114,7 @@ DATA_DIR="${TESTS_DIR}/data/dummy/"
 for FORMAT in ${FORMATS[@]} ; do
   for LOCATION in ${LOCATIONS[@]} ; do
     INSTANCES_PATH="/${LOCATION}/"
-    OUTPUT=$(post_$FORMAT "$INSTANCES_PATH" "${DATA_DIR}/${LOCATION}.${FORMAT}")
+    OUTPUT=$(post_$FORMAT "$INSTANCES_PATH" "${DATA_DIR}/${LOCATION}.${FORMAT#occi_}")
 
     RETVAL=$?
     if [ $RETVAL -ne 0 ] ; then

--- a/test/integration/one.sh
+++ b/test/integration/one.sh
@@ -27,7 +27,7 @@ printf "######################################################################\n
 printf "############################## Model #################################\n"
 printf "######################################################################\n"
 
-FORMATS=(plain json)
+FORMATS=(plain json occi_json)
 
 for FORMAT in ${FORMATS[@]} ; do
   MODEL_PATH="/-/"
@@ -69,7 +69,7 @@ printf "######################################################################\n
 printf "############################# Create #################################\n"
 printf "######################################################################\n"
 
-FORMATS=(json plain)
+FORMATS=(occi_json json plain)
 LOCATIONS=(compute network storage ipreservation securitygroup)
 # LOCATIONS+=(networkinterface storagelink securitygrouplink)
 DATA_DIR="${TESTS_DIR}/data/one/"
@@ -79,7 +79,7 @@ for FORMAT in ${FORMATS[@]} ; do
   for LOCATION in ${LOCATIONS[@]} ; do
     INSTANCES_PATH="/${LOCATION}/"
     ENTITY=$(mktemp "/tmp/rocci-server-integration-${LOCATION}-${FORMAT}.XXXXXXXXXXXX")
-    cp "${DATA_DIR}/${LOCATION}.${FORMAT}" "$ENTITY"
+    cp "${DATA_DIR}/${LOCATION}.${FORMAT#occi_}" "$ENTITY"
     sed -i "s/a262ad95\-c093\-4814\-8c0d\-bc6d475bb845/${LOCATION}\-a262ad95\-c093\-4814\-8c0d\-bc6d475bb845\-$FORMAT/g" "$ENTITY"
     OUTPUT=$(post_$FORMAT "$INSTANCES_PATH" "$ENTITY")
 
@@ -101,7 +101,7 @@ printf "######################################################################\n
 printf "############################## Get ###################################\n"
 printf "######################################################################\n"
 
-FORMATS=(json plain)
+FORMATS=(occi_json json plain)
 
 for FORMAT in ${FORMATS[@]} ; do
   for CLEANUP in ${CLEANUPS[@]} ; do


### PR DESCRIPTION
Using an alias can cause confusion when rendering responses. When `occi+json` is specified, `occi+json` MUST be returned.