### PR TITLE
Updated resource templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git clone https://github.com/the-rocci-project/rOCCI-server.git
 cd rOCCI-server
 bundle install --deployment --without development test
 
-bundle exec bin/oneresources create --endpoint http://one.example.org:2633/RPC2 # --username USER --password PASSWD
+bundle exec bin/oneresource create --endpoint http://one.example.org:2633/RPC2 # --username USER --password PASSWD
 
 export RAILS_ENV=production
 export HOST=0.0.0.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,7 +95,7 @@ Vagrant.configure('2') do |config|
         export ROCCI_SERVER_BACKEND=opennebula
         export ROCCI_SERVER_OPENNEBULA_ENDPOINT=http://#{ONE_ADDR}:2633/RPC2
 
-        rvm 2.4.1 do bundle exec bin/oneresources create --endpoint $ROCCI_SERVER_OPENNEBULA_ENDPOINT
+        rvm 2.4.1 do bundle exec bin/oneresource create --endpoint $ROCCI_SERVER_OPENNEBULA_ENDPOINT
       fi
 
       export RAILS_ENV=production

--- a/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.class.yml
+++ b/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.class.yml
@@ -3,5 +3,5 @@ type: !ruby/class String
 required: true
 mutable: false
 default: ~
-description: Device identifier of the requested GPU device.
+description: Class identifier of the requested PCI device.
 pattern: ~

--- a/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.count.yml
+++ b/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.count.yml
@@ -3,5 +3,5 @@ type: !ruby/class Integer
 required: true
 mutable: false
 default: ~
-description: Number of GPU devices.
+description: Number of PCI devices.
 pattern: ~

--- a/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.device.yml
+++ b/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.device.yml
@@ -3,5 +3,5 @@ type: !ruby/class String
 required: true
 mutable: false
 default: ~
-description: Vendor identifier of the requested GPU device.
+description: Device identifier of the requested PCI device.
 pattern: ~

--- a/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.vendor.yml
+++ b/app/lib/backends/dummy/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.vendor.yml
@@ -3,5 +3,5 @@ type: !ruby/class String
 required: true
 mutable: false
 default: ~
-description: Class identifier of the requested GPU device.
+description: Vendor identifier of the requested PCI device.
 pattern: ~

--- a/app/lib/backends/dummy/warehouse/mixins/res_small.yml
+++ b/app/lib/backends/dummy/warehouse/mixins/res_small.yml
@@ -8,18 +8,18 @@ attributes:
   - occi.compute.memory
   - occi.compute.speed
   - occi.compute.ephemeral_storage.size
-  - eu.egi.fedcloud.compute.gpu.count
-  - eu.egi.fedcloud.compute.gpu.vendor
-  - eu.egi.fedcloud.compute.gpu.class
-  - eu.egi.fedcloud.compute.gpu.device
+  - eu.egi.fedcloud.compute.pci.count
+  - eu.egi.fedcloud.compute.pci.vendor
+  - eu.egi.fedcloud.compute.pci.class
+  - eu.egi.fedcloud.compute.pci.device
 attribute_defaults:
   occi.compute.cores: 1
   occi.compute.memory: 1.7
   occi.compute.ephemeral_storage.size: 10.0
-  eu.egi.fedcloud.compute.gpu.count: 1
-  eu.egi.fedcloud.compute.gpu.vendor: 10de
-  eu.egi.fedcloud.compute.gpu.class: '0302'
-  eu.egi.fedcloud.compute.gpu.device: '1024'
+  eu.egi.fedcloud.compute.pci.count: 1
+  eu.egi.fedcloud.compute.pci.vendor: 10de
+  eu.egi.fedcloud.compute.pci.class: '0302'
+  eu.egi.fedcloud.compute.pci.device: '1024'
 location: /mixin/resource_tpl/small
 applies:
   - http://schemas.ogf.org/occi/infrastructure#compute

--- a/app/lib/backends/dummy/warehouse/mixins/resource_large.yml
+++ b/app/lib/backends/dummy/warehouse/mixins/resource_large.yml
@@ -8,18 +8,18 @@ attributes:
   - occi.compute.memory
   - occi.compute.speed
   - occi.compute.ephemeral_storage.size
-  - eu.egi.fedcloud.compute.gpu.count
-  - eu.egi.fedcloud.compute.gpu.vendor
-  - eu.egi.fedcloud.compute.gpu.class
-  - eu.egi.fedcloud.compute.gpu.device
+  - eu.egi.fedcloud.compute.pci.count
+  - eu.egi.fedcloud.compute.pci.vendor
+  - eu.egi.fedcloud.compute.pci.class
+  - eu.egi.fedcloud.compute.pci.device
 attribute_defaults:
   occi.compute.cores: 4
   occi.compute.memory: 16.0
   occi.compute.ephemeral_storage.size: 80.0
-  eu.egi.fedcloud.compute.gpu.count: 2
-  eu.egi.fedcloud.compute.gpu.vendor: 10de
-  eu.egi.fedcloud.compute.gpu.class: '0302'
-  eu.egi.fedcloud.compute.gpu.device: '1024'
+  eu.egi.fedcloud.compute.pci.count: 2
+  eu.egi.fedcloud.compute.pci.vendor: 10de
+  eu.egi.fedcloud.compute.pci.class: '0302'
+  eu.egi.fedcloud.compute.pci.device: '1024'
 location: /mixin/resource_tpl/large
 applies:
   - http://schemas.ogf.org/occi/infrastructure#compute

--- a/app/lib/backends/opennebula/compute.rb
+++ b/app/lib/backends/opennebula/compute.rb
@@ -107,7 +107,7 @@ module Backends
         %i[set_context! set_size! set_security_groups! set_cluster!].each { |mtd| send(mtd, template, compute) }
 
         template = template.template_str
-        %i[add_custom! add_gpu! add_nics! add_disks!].each { |mtd| send(mtd, template, compute) }
+        %i[add_custom! add_pci! add_nics! add_disks!].each { |mtd| send(mtd, template, compute) }
 
         template
       end

--- a/app/lib/backends/opennebula/constants/compute.rb
+++ b/app/lib/backends/opennebula/constants/compute.rb
@@ -49,12 +49,12 @@ module Backends
           'occi.compute.ephemeral_storage.size' => lambda do |vm, val|
             (vm['TEMPLATE/DISK[1]/SIZE'].to_f / 1024) <= val.to_f
           end,
-          'eu.egi.fedcloud.compute.gpu.count' => lambda do |vm, val|
+          'eu.egi.fedcloud.compute.pci.count' => lambda do |vm, val|
             Backends::Opennebula::Helpers::Counter.xml_elements(vm, 'TEMPLATE/PCI') == val.to_i
           end,
-          'eu.egi.fedcloud.compute.gpu.vendor' => ->(vm, val) { vm['TEMPLATE/PCI[1]/VENDOR'] == val },
-          'eu.egi.fedcloud.compute.gpu.class' => ->(vm, val) { vm['TEMPLATE/PCI[1]/CLASS'] == val },
-          'eu.egi.fedcloud.compute.gpu.device' => ->(vm, val) { vm['TEMPLATE/PCI[1]/DEVICE'] == val }
+          'eu.egi.fedcloud.compute.pci.vendor' => ->(vm, val) { vm['TEMPLATE/PCI[1]/VENDOR'] == val },
+          'eu.egi.fedcloud.compute.pci.class' => ->(vm, val) { vm['TEMPLATE/PCI[1]/CLASS'] == val },
+          'eu.egi.fedcloud.compute.pci.device' => ->(vm, val) { vm['TEMPLATE/PCI[1]/DEVICE'] == val }
         }.freeze
 
         # Mixins to add for contextualization attributes

--- a/app/lib/backends/opennebula/helpers/virtual_machine_mutators.rb
+++ b/app/lib/backends/opennebula/helpers/virtual_machine_mutators.rb
@@ -60,18 +60,18 @@ module Backends
         end
 
         # :nodoc:
-        def add_gpu!(template_str, compute)
-          return unless compute['eu.egi.fedcloud.compute.gpu.count']
+        def add_pci!(template_str, compute)
+          return unless compute['eu.egi.fedcloud.compute.pci.count']
 
-          gpu = {
-            vendor: compute['eu.egi.fedcloud.compute.gpu.vendor'],
-            klass: compute['eu.egi.fedcloud.compute.gpu.class'],
-            device: compute['eu.egi.fedcloud.compute.gpu.device']
+          pci = {
+            vendor: compute['eu.egi.fedcloud.compute.pci.vendor'],
+            klass: compute['eu.egi.fedcloud.compute.pci.class'],
+            device: compute['eu.egi.fedcloud.compute.pci.device']
           }
           data = { instances: [] }
-          compute['eu.egi.fedcloud.compute.gpu.count'].times { data[:instances] << gpu }
+          compute['eu.egi.fedcloud.compute.pci.count'].times { data[:instances] << pci }
 
-          logger.debug { "#{self.class}: Adding GPU(s) #{data[:instances].first.inspect}" }
+          logger.debug { "#{self.class}: Adding PCI(s) #{data[:instances].first.inspect}" }
           add_erb! template_str, data, 'compute_pci.erb'
         end
 

--- a/app/lib/backends/opennebula/model_extender.rb
+++ b/app/lib/backends/opennebula/model_extender.rb
@@ -28,8 +28,8 @@ module Backends
       RES_TPL_ATTRS = %w[
         occi.compute.cores occi.compute.memory occi.compute.architecture
         occi.compute.ephemeral_storage.size occi.compute.speed
-        eu.egi.fedcloud.compute.gpu.count eu.egi.fedcloud.compute.gpu.vendor
-        eu.egi.fedcloud.compute.gpu.class eu.egi.fedcloud.compute.gpu.device
+        eu.egi.fedcloud.compute.pci.count eu.egi.fedcloud.compute.pci.vendor
+        eu.egi.fedcloud.compute.pci.class eu.egi.fedcloud.compute.pci.device
       ].freeze
       ALLOWED_UNAMES = %w[oneadmin].freeze
 

--- a/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.class.yml
+++ b/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.class.yml
@@ -3,5 +3,5 @@ type: !ruby/class String
 required: true
 mutable: false
 default: ~
-description: Device identifier of the requested GPU device.
+description: Class identifier of the requested PCI device.
 pattern: ~

--- a/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.count.yml
+++ b/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.count.yml
@@ -3,5 +3,5 @@ type: !ruby/class Integer
 required: true
 mutable: false
 default: ~
-description: Number of GPU devices.
+description: Number of PCI devices.
 pattern: ~

--- a/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.device.yml
+++ b/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.device.yml
@@ -3,5 +3,5 @@ type: !ruby/class String
 required: true
 mutable: false
 default: ~
-description: Vendor identifier of the requested GPU device.
+description: Device identifier of the requested PCI device.
 pattern: ~

--- a/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.vendor.yml
+++ b/app/lib/backends/opennebula/warehouse/mixins/attributes/eu.egi.fedcloud.compute.pci.vendor.yml
@@ -3,5 +3,5 @@ type: !ruby/class String
 required: true
 mutable: false
 default: ~
-description: Class identifier of the requested GPU device.
+description: Vendor identifier of the requested PCI device.
 pattern: ~

--- a/app/lib/backends/opennebula/warehouse/mixins/res_default_template.yml
+++ b/app/lib/backends/opennebula/warehouse/mixins/res_default_template.yml
@@ -8,10 +8,10 @@ attributes:
   - occi.compute.memory
   - occi.compute.speed
   - occi.compute.ephemeral_storage.size
-  - eu.egi.fedcloud.compute.gpu.count
-  - eu.egi.fedcloud.compute.gpu.vendor
-  - eu.egi.fedcloud.compute.gpu.class
-  - eu.egi.fedcloud.compute.gpu.device
+  - eu.egi.fedcloud.compute.pci.count
+  - eu.egi.fedcloud.compute.pci.vendor
+  - eu.egi.fedcloud.compute.pci.class
+  - eu.egi.fedcloud.compute.pci.device
 location: /mixin/resource_tpl/default_template
 applies:
   - http://schemas.ogf.org/occi/infrastructure#compute

--- a/bin/oneresource
+++ b/bin/oneresource
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+
 require 'thor'
 require 'pathname'
 require 'json'

--- a/lib/resources/custom/occi_legacy_rocci_server.json
+++ b/lib/resources/custom/occi_legacy_rocci_server.json
@@ -1,0 +1,92 @@
+[
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#extra_large",
+    "title": "Extra Large Instance - 8 cores and 8 GB RAM",
+    "occi.compute.cores": 8,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 8.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#mem_extra_large",
+    "title": "Extra Large Instance - 8 cores and 32 GB RAM",
+    "occi.compute.cores": 8,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 32.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#mammoth",
+    "title": "Mammoth Instance - 16 cores and 16 GB RAM",
+    "occi.compute.cores": 16,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 16.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#mem_mammoth",
+    "title": "Mammoth Instance - 16 cores and 64 GB RAM",
+    "occi.compute.cores": 16,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 64.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#goliath",
+    "title": "Goliath Instance - 24 cores and 24 GB RAM",
+    "occi.compute.cores": 24,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 24.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#mem_goliath",
+    "title": "Goliath Instance - 24 cores and 96 GB RAM",
+    "occi.compute.cores": 24,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 96.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#atlas",
+    "title": "Atlas Instance - 32 cores and 32 GB RAM",
+    "occi.compute.cores": 32,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 32.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#mem_atlas",
+    "title": "Atlas Instance - 32 cores and 128 GB RAM",
+    "occi.compute.cores": 32,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 128.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#universe",
+    "title": "Universe Instance - 48 cores and 48 GB RAM",
+    "occi.compute.cores": 48,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 48.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  },
+  {
+    "identifier": "http://schemas.cesnet.cz/occi/infrastructure/resource_tpl#mem_universe",
+    "title": "Universe Instance - 48 cores and 192 GB RAM",
+    "occi.compute.cores": 48,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 192.0,
+    "occi.compute.ephemeral_storage.size": 80.0,
+    "occi.compute.architecture": "x64"
+  }
+]

--- a/lib/resources/gpu/occi_crtp_11_w_gpu.json
+++ b/lib/resources/gpu/occi_crtp_11_w_gpu.json
@@ -1,0 +1,68 @@
+[
+  {
+    "identifier": "http://schemas.fedcloud.egi.eu/occi/infrastructure/compute/template/1.1#small_gpu",
+    "title": "CRTP/1.1 Resource Template - Small with GPU",
+    "occi.compute.cores": 1,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 1.0,
+    "occi.compute.ephemeral_storage.size": 10.0,
+    "occi.compute.architecture": "x64",
+    "eu.egi.fedcloud.compute.pci.count": "1",
+    "eu.egi.fedcloud.compute.pci.class": "0302"
+  },
+  {
+    "identifier": "http://schemas.fedcloud.egi.eu/occi/infrastructure/compute/template/1.1#medium_gpu",
+    "title": "CRTP/1.1 Resource Template - Medium with GPU",
+    "occi.compute.cores": 2,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 2.0,
+    "occi.compute.ephemeral_storage.size": 20.0,
+    "occi.compute.architecture": "x64",
+    "eu.egi.fedcloud.compute.pci.count": "1",
+    "eu.egi.fedcloud.compute.pci.class": "0302"
+  },
+  {
+    "identifier": "http://schemas.fedcloud.egi.eu/occi/infrastructure/compute/template/1.1#large_gpu",
+    "title": "CRTP/1.1 Resource Template - Large with GPU",
+    "occi.compute.cores": 4,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 4.0,
+    "occi.compute.ephemeral_storage.size": 40.0,
+    "occi.compute.architecture": "x64",
+    "eu.egi.fedcloud.compute.pci.count": "1",
+    "eu.egi.fedcloud.compute.pci.class": "0302"
+  },
+  {
+    "identifier": "http://schemas.fedcloud.egi.eu/occi/infrastructure/compute/template/1.1#mem_small_gpu",
+    "title": "CRTP/1.1 Resource Template - Small with 4x Memory and GPU",
+    "occi.compute.cores": 1,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 4.0,
+    "occi.compute.ephemeral_storage.size": 10.0,
+    "occi.compute.architecture": "x64",
+    "eu.egi.fedcloud.compute.pci.count": "1",
+    "eu.egi.fedcloud.compute.pci.class": "0302"
+  },
+  {
+    "identifier": "http://schemas.fedcloud.egi.eu/occi/infrastructure/compute/template/1.1#mem_medium_gpu",
+    "title": "CRTP/1.1 Resource Template - Medium with 4x Memory and GPU",
+    "occi.compute.cores": 2,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 8.0,
+    "occi.compute.ephemeral_storage.size": 20.0,
+    "occi.compute.architecture": "x64",
+    "eu.egi.fedcloud.compute.pci.count": "1",
+    "eu.egi.fedcloud.compute.pci.class": "0302"
+  },
+  {
+    "identifier": "http://schemas.fedcloud.egi.eu/occi/infrastructure/compute/template/1.1#mem_large_gpu",
+    "title": "CRTP/1.1 Resource Template - Large with 4x Memory and GPU",
+    "occi.compute.cores": 4,
+    "occi.compute.speed": 1.0,
+    "occi.compute.memory": 16.0,
+    "occi.compute.ephemeral_storage.size": 40.0,
+    "occi.compute.architecture": "x64",
+    "eu.egi.fedcloud.compute.pci.count": "1",
+    "eu.egi.fedcloud.compute.pci.class": "0302"
+  }
+]


### PR DESCRIPTION
* Renamed GPU attributes to PCI (since they have a configurable class)
* Added GPU-enabled resource templates and legacy templates from rOCCI-server < v2
* Renamed `bin/oneresources` to `bin/oneresource` to follow conventions